### PR TITLE
Revert naming back to TESTING_CLIENT_ID and SECRET to use in circle ci context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,5 +38,4 @@ jobs:
 workflows:
   build-and-test:
     jobs:
-      - build-and-test:
-          context: visits-public-e2e-tests
+      - build-and-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,4 +38,5 @@ jobs:
 workflows:
   build-and-test:
     jobs:
-      - build-and-test
+      - build-and-test:
+          context: visits-public-e2e-tests

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ playwright-report/
 .env
 .env.dev
 .env.staging
+
+.idea

--- a/src/setup/env.ts
+++ b/src/setup/env.ts
@@ -16,6 +16,6 @@ export default class ENV {
 
   public static readonly HMPPS_AUTH_URL = process.env.HMPPS_AUTH_URL
   public static readonly TEST_HELPER_API_URL = process.env.TEST_HELPER_API_URL
-  public static readonly CLIENT_ID = process.env.CLIENT_ID
-  public static readonly CLIENT_SECRET = process.env.CLIENT_SECRET
+  public static readonly TESTING_CLIENT_ID = process.env.TESTING_CLIENT_ID
+  public static readonly TESTING_CLIENT_SECRET = process.env.TESTING_CLIENT_SECRET
 }

--- a/src/support/testingHelperClient.ts
+++ b/src/support/testingHelperClient.ts
@@ -5,7 +5,7 @@ import { IApplication } from '../data/IApplication'
 const testHelperUri = process.env.TEST_HELPER_API_URL
 
 export const getAccessToken = async ({ request }: { request: APIRequestContext }) => {
-  const basicAuthToken = btoa(`${process.env.CLIENT_ID}:${process.env.CLIENT_SECRET}`)
+  const basicAuthToken = btoa(`${process.env.TESTING_CLIENT_ID}:${process.env.TESTING_CLIENT_SECRET}`)
   const authUri = `${process.env.HMPPS_AUTH_URL}/oauth/token`
 
   const response = await request.post(authUri, {


### PR DESCRIPTION
## What does this PR do?
To distinguish between normal CLIENT_ID and this projects client ID inside of a pipeline, i'm reverting the naming convention back to TESTING_CLIENT_... , this will let me set it in the circle ci context i've created and use it without clashes.